### PR TITLE
Fixed compile on modern system,  deprecation warnings

### DIFF
--- a/source/iked/conf.parse.yy
+++ b/source/iked/conf.parse.yy
@@ -41,7 +41,7 @@
 
 %skeleton "lalr1.cc"
 %defines
-%define "parser_class_name" "conf_parser"
+%define api.parser.class {conf_parser}
 
 %{
 
@@ -56,7 +56,7 @@
 %lex-param   { IKED & iked }
 %locations
 %debug
-%error-verbose
+%define parse.error verbose
 
 // Symbols.
 %union

--- a/source/iked/iked.cpp
+++ b/source/iked/iked.cpp
@@ -39,6 +39,7 @@
  *
  */
 
+#include <openssl/rand.h>
 #include "iked.h"
 
 long _IKED_EXEC::func( void * arg )
@@ -46,6 +47,10 @@ long _IKED_EXEC::func( void * arg )
 	long result = iked_func( arg );
 
 	// openssl thread cleanup
+        #if OPENSSL_API_COMPAT < 0x10000000L
+        void ERR_remove_state(unsigned long pid);
+        #endif
+
 	ERR_remove_state( 0 );
 
 	return result;
@@ -53,7 +58,7 @@ long _IKED_EXEC::func( void * arg )
 
 bool _IKED::rand_bytes( void * buff, long size )
 {
-	RAND_pseudo_bytes( ( unsigned char * ) buff, size );
+	RAND_bytes( ( unsigned char * ) buff, size );
 	return true;
 }
 


### PR DESCRIPTION
Fixed openssl deprecation warnings

Changed to use RAND_bytes instead of RAND_pseudo_bytes

Fixed yy file warnings about deprecated defines