### PR TITLE
Fix on crypto.cpp setting order of shared parameters dh->p and dh->g

### DIFF
--- a/source/iked/crypto.cpp
+++ b/source/iked/crypto.cpp
@@ -452,11 +452,10 @@ bool dh_init( long group, DH ** dh_data, long * dh_size )
 	//
 	// generate private and public DH values
 	//
+	DH_set0_pqg(dh, p, NULL, g);
 
 	if( !DH_generate_key( dh ) )
 		goto dh_failed;
-
-	DH_set0_pqg(dh, p, NULL, g);
 
 	*dh_data = dh;
 	*dh_size = BN_num_bytes( p );


### PR DESCRIPTION
DH_generate_key() expects dh to contain the shared parameters dh->p and dh->g but on original code, after initializing the parameters p and g, DH_generate_key() is called before calling the function DH_set0_pqg(dh, p, NULL, g); which sets p and g inside DH. 
So, using qikea, when I was trying to connect to Vpn (tested on AlmaLinux 8), the result was
```
Mar 14 16:22:59 WORKGROUP systemd[2463]: Started Tracker metadata extractor.
Mar 14 16:23:41 WORKGROUP kernel: iked[9077]: segfault at 8 ip 00007f97fbd0e7b5 sp 00007f97ebffe600 error 4 in libcrypto.so.1.1.1k[7f97fbc51000+2b6000]
Mar 14 16:23:41 WORKGROUP systemd[1]: Started Process Core Dump (PID 9078/UID 0). 
```
moving DH_set0_pqg() before DH_generate_key(), everything seems to work fine, and I connect to VPN
